### PR TITLE
wclient: implement ability to execute external renderers

### DIFF
--- a/examples/wayland/wayland-client-main.c
+++ b/examples/wayland/wayland-client-main.c
@@ -5,7 +5,6 @@
 
 #include "wclient-common.h"
 
-
 static uint8_t next_color(bool *up, uint8_t cur, unsigned int mod) {
   uint8_t next;
 
@@ -19,8 +18,26 @@ static uint8_t next_color(bool *up, uint8_t cur, unsigned int mod) {
 }
 
 
+void render(int *cbuf, void *data) {
+  struct uvr_wc *wc = data;
+
+  unsigned int width = 3840, height = 2160, bytes_per_pixel = 4;
+  unsigned int UNUSED stride = width * bytes_per_pixel;
+  bool r_up = true, g_up = true, b_up = true;
+
+  srand(time(NULL));
+  uint8_t r = next_color(&r_up, rand() % 0xff, 20);
+  uint8_t g = next_color(&g_up, rand() % 0xff, 10);
+  uint8_t b = next_color(&b_up, rand() % 0xff, 5);
+
+  for (unsigned int x = 0; x < width; x++)
+    for (unsigned int y = 0; y < height; y++)
+      *(uint32_t *) &wc->wcbuffs.uvrwcshmbufs[*cbuf].shm_pool_data[stride * x + y * bytes_per_pixel] = (r << 16) | (g << 8) | b;
+}
+
+
 /*
- * Example code demonstrating how use Vulkan with X11
+ * Example code demonstrating how to wayland shm buffers
  */
 int main(void) {
   struct uvr_wc wc;
@@ -36,43 +53,33 @@ int main(void) {
   wc.wcinterfaces = uvr_wc_core_interface_create(&wcinterfaces_info);
   if (!wc.wcinterfaces.display || !wc.wcinterfaces.registry || !wc.wcinterfaces.compositor) goto exit_error;
 
-  int width = 3840, height = 2160, bytes_per_pixel = 4;
   struct uvr_wc_buffer_create_info uvrwcbuff_info = {
     .uvrwccore = &wc.wcinterfaces, .buffer_count = 2,
-    .width = width, .height = height, .bytes_per_pixel = bytes_per_pixel,
+    .width = 3840, .height = 2160, .bytes_per_pixel = 4,
     .wl_pix_format = WL_SHM_FORMAT_XRGB8888
   };
 
   wc.wcbuffs = uvr_wc_buffer_create(&uvrwcbuff_info);
-  if (!wc.wcbuffs.buffers)
+  if (!wc.wcbuffs.uvrwcwlbufs || !wc.wcbuffs.uvrwcwlbufs)
     goto exit_error;
 
+  static int cbuf = 0;
   struct uvr_wc_surface_create_info uvrwcsurf_info = {
     .uvrwccore = &wc.wcinterfaces,
     .uvrwcbuff = &wc.wcbuffs,
     .appname = "Example Window",
-    .fullscreen = true
+    .fullscreen = true,
+    .renderer = &render,
+    .rendererdata = &wc,
+    .renderercbuf = &cbuf
   };
 
   wc.wcsurf = uvr_wc_surface_create(&uvrwcsurf_info);
   if (!wc.wcsurf.surface) goto exit_error;
 
-  int stride = width * bytes_per_pixel, calls = 2;
-  bool r_up = true, g_up = true, b_up = true;
-
-  srand(time(NULL));
-  uint8_t r = next_color(&r_up, rand() % 0xff, 20);
-  uint8_t g = next_color(&g_up, rand() % 0xff, 10);
-  uint8_t b = next_color(&b_up, rand() % 0xff, 5);
-
-  for (int x = 0; x < width; x++)
-    for (int y = 0; y < height; y++)
-      *(uint32_t *) &wc.wcbuffs.shm_pool_data[stride * x + y * bytes_per_pixel] = (r << 16) | (g << 8) | b;
-
-  for (int call = 0; call < calls; call++)
-    uvr_wc_process_events(&wc.wcinterfaces);
-
-  sleep(5);
+  while (wl_display_dispatch(wc.wcinterfaces.display) != -1 && wc.wcsurf.running) {
+    // Leave blank
+  }
 
 exit_error:
   wcd.uvr_wc_core_interface = wc.wcinterfaces;


### PR DESCRIPTION
Commit includes:
	* internal swapping between shared memory buffers
        * bug fix where wl_shm_pool is free'd buffer_count times.
	  Thus, causing segfaults
        * Adds function pointer with arguments being pointer to
	  an integer and a pointer to a void data type.
          The address given to the integer is used internally by
          the api to swap out buffers.

Signed-off-by: Vincent Davis Jr <vince@underview.tech>